### PR TITLE
Rename Azure connections 'role' field to 'roles'

### DIFF
--- a/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
@@ -20,7 +20,7 @@ namespace Bicep.Core.TypeSystem.Radius.V3
 
         public static ComponentData MakeService()
         {
-            var roleType = new TypedArrayType(
+            var rolesType = new TypedArrayType(
                 itemReference: LanguageConstants.String,
                 validationFlags: TypeSymbolValidationFlags.Default);
 
@@ -37,7 +37,7 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                         {
                             new TypeProperty("kind", new StringLiteralType(b.Type.FormatKind()), TypePropertyFlags.Required, "The kind of connection"),
                             new TypeProperty("source", LanguageConstants.String, TypePropertyFlags.Required, "The source of the connection"),
-                            new TypeProperty("role", roleType, TypePropertyFlags.None, "RBAC configuration to be applied on the connection"),
+                            new TypeProperty("roles", rolesType, TypePropertyFlags.None, "RBAC configuration to be applied on the connection"),
                         },
                         additionalPropertiesType: null,
                         additionalPropertiesFlags: TypePropertyFlags.None,
@@ -239,7 +239,7 @@ In this example the `web` port documents that the container is listening on port
         {
             var members = new List<ObjectType>();
 
-            var roleType = new TypedArrayType(
+            var rolesType = new TypedArrayType(
                 itemReference: LanguageConstants.String,
                 validationFlags: TypeSymbolValidationFlags.Default);
 
@@ -256,7 +256,7 @@ In this example the `web` port documents that the container is listening on port
                         {
                             new TypeProperty("kind", new StringLiteralType(b.Type.FormatKind()), TypePropertyFlags.Required, "The kind of connection"),
                             new TypeProperty("source", LanguageConstants.String, TypePropertyFlags.Required, "The source of the connection"),
-                            new TypeProperty("role", roleType, TypePropertyFlags.None, "RBAC configuration to be applied on the connection"),
+                            new TypeProperty("roles", rolesType, TypePropertyFlags.None, "RBAC configuration to be applied on the connection"),
                         },
                         additionalPropertiesType: null,
                         additionalPropertiesFlags: TypePropertyFlags.None,


### PR DESCRIPTION
This came up in Azure/radius#1546. Connections role field is currently an array with support for multiple role names, so renaming it to roles is more intuitive.
https://github.com/Azure/radius/blob/main/docs/content/concepts/appmodel-concept/connections-model/snippets/azure-connection.bicep#L14