### PR TITLE
Add trimMatch to gateways

### DIFF
--- a/src/Bicep.Core/TypeSystem/Radius/V3/CommonBindings.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/CommonBindings.cs
@@ -22,6 +22,7 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                     "type",
                     new UnionType("type", ImmutableArray.Create<ITypeReference>(new StringLiteralType("prefix"), new StringLiteralType("exact"))),
                     TypePropertyFlags.None, description: "Specifies the type of matching to match the path on. Supported values: 'prefix', 'exact'"),
+                new TypeProperty("trimMatch", LanguageConstants.Bool, TypePropertyFlags.None, description: "Specifies whether to removed the matched path on the incoming request."),
             },
             additionalPropertiesType: null,
             additionalPropertiesFlags: TypePropertyFlags.None);


### PR DESCRIPTION
Part of https://github.com/Azure/radius/issues/1393

From listening to the customer call, the main feature they want is the ability to trim the prefix match after a rule has been matched on.
