### PR TITLE
No warning from bicep build for extensibility

### DIFF
--- a/src/Bicep.Cli/Commands/BuildCommand.cs
+++ b/src/Bicep.Cli/Commands/BuildCommand.cs
@@ -36,11 +36,6 @@ namespace Bicep.Cli.Commands
         {
             var inputPath = PathHelper.ResolvePath(args.InputFile);
 
-            if (invocationContext.EmitterSettings.EnableSymbolicNames)
-            {
-                logger.LogWarning(CliResources.SymbolicNamesDisclaimerMessage);
-            }
-
             var compilation = await compilationService.CompileAsync(inputPath, args.NoRestore);
 
             if (diagnosticLogger.ErrorCount < 1)


### PR DESCRIPTION
I think this is causing bicep validation errors.