### PR TITLE
Fix instance functions on resource-typed parameters

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -122,6 +122,7 @@ output name string = p.name
 output type string = p.type
 output apiVersion string = p.apiVersion
 output accessTier string = p.properties.accessTier
+output keys object = p.listKeys()
 ");
             result.Should().NotHaveAnyDiagnostics();
 
@@ -149,6 +150,11 @@ output accessTier string = p.properties.accessTier
             {
                 ["type"] = new JValue("string"),
                 ["value"] = new JValue("[reference(parameters('p'), '2019-06-01').accessTier]"),
+            });
+            result.Template.Should().HaveValueAtPath("$.outputs.keys", new JObject()
+            {
+                ["type"] = new JValue("object"),
+                ["value"] = new JValue("[listKeys(parameters('p'), '2019-06-01')]"),
             });
         }
 

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -140,11 +140,11 @@ namespace Bicep.Core.Emit
                             return CreateFunction(
                                 instanceFunctionCall.Name.IdentifierName,
                                 instanceFunctionCall.Arguments.Select(a => ConvertExpression(a.Expression)));
-                        case ResourceSymbol resourceSymbol when context.SemanticModel.ResourceMetadata.TryLookup(resourceSymbol.DeclaringSyntax) is DeclaredResourceMetadata resource:
+                        case DeclaredSymbol declaredSymbol when context.SemanticModel.ResourceMetadata.TryLookup(declaredSymbol.DeclaringSyntax) is ResourceMetadata resource:
                             if (instanceFunctionCall.Name.IdentifierName.StartsWithOrdinalInsensitively("list"))
                             {
                                 var converter = indexExpression is not null ?
-                                    CreateConverterForIndexReplacement(resource.NameSyntax, indexExpression, instanceFunctionCall) :
+                                    CreateConverterForIndexReplacement(((DeclaredResourceMetadata)resource).NameSyntax, indexExpression, instanceFunctionCall) :
                                     this;
 
                                 // Handle list<method_name>(...) method on resource symbol - e.g. stgAcc.listKeys()


### PR DESCRIPTION
Fixes: #6180

This change fixes a bug where the compiler does not understand how to
codegen an instance function call for a parameter. This case was just
not handled by the code generator and results in a crash. We'll also
need to fix this upstream in `azure/bicep`.
