### PR TITLE
sqlserver should be fqdn, database just the name

### DIFF
--- a/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/KnownComponents.cs
@@ -881,9 +881,9 @@ For Azure, this property will accept a resource ID of a `Microsoft.Sql/servers/d
 
 Resources provided by the developer will not be modified or deleted by Radius. Use this property to attach resources created with Bicep or any other mechanism."),
                     new TypeProperty("server", LanguageConstants.String, TypePropertyFlags.None, description:
-                    "The name of the SQL database."),
+                    "Fully Qualified Domain Name of the SQL server."),
                     new TypeProperty("database", LanguageConstants.String, TypePropertyFlags.None, description:
-                    "The fully qualified domain name of the SQL database."),
+                    "name of the SQL database."),
                 },
             };
         }


### PR DESCRIPTION


* [X] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style


Change the sql server property descriptions so that the database refers to the name of database, while server captures the FQDN of sql server
