### PR TITLE
Making radius types look like azure types

### DIFF
--- a/src/Bicep.Core/Semantics/Metadata/ResourceMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ResourceMetadata.cs
@@ -13,6 +13,6 @@ namespace Bicep.Core.Semantics.Metadata
     {
         public ResourceTypeReference TypeReference => Type.TypeReference;
 
-        public bool IsAzResource => Type.DeclaringNamespace.ProviderNameEquals(AzNamespaceType.BuiltInName);
+        public bool IsAzResource => Type.DeclaringNamespace.ProviderNameEquals(AzNamespaceType.BuiltInName) || Type.DeclaringNamespace.ProviderNameEquals(RadiusNamespaceType.BuiltInName);
     }
 }


### PR DESCRIPTION
Part of our discussion with the bicep team, we are going to pivot our types to look more like azure resources.

From what I've seen, these types look correct with only this change!