### PR TITLE
Added routes information in the HTTP Route Resource

### DIFF
--- a/src/Bicep.Core/TypeSystem/Radius/V3/CommonBindings.cs
+++ b/src/Bicep.Core/TypeSystem/Radius/V3/CommonBindings.cs
@@ -20,7 +20,8 @@ namespace Bicep.Core.TypeSystem.Radius.V3
                 new TypeProperty("scheme", LanguageConstants.String, TypePropertyFlags.ReadOnly),
                 new TypeProperty("host", LanguageConstants.String, TypePropertyFlags.ReadOnly),
                 new TypeProperty("port", LanguageConstants.Int, TypePropertyFlags.None),
-                new TypeProperty("routes",
+                new TypeProperty(
+                    "routes",
                     new TypedArrayType(
                         itemReference: new ObjectType (
                             name: "routes",


### PR DESCRIPTION
# Description

As discussed in the [App model of my traffic-splitting project](https://github.com/project-radius/app-model/issues/16), we will achieve traffic-splitting using the resource of Http Route. Currently, the resource does not have the "routes" property, nor does it have the nested properties of "weight" and "destination". We need to configure the bicep compiler and add these properties to this resource.  


## Testing:

- For testing the compiler, I am going to use the bicep VS Code Extension. After modifying the related files, I created a new Bicep VSCode Extension (using @willdavsmith's script, very helpful 😄 ) and then created a new bicep file. No errors and warnings were thrown.

<img width="407" alt="Screen Shot 2022-05-24 at 4 35 08 PM" src="https://user-images.githubusercontent.com/67586945/170148748-59c3c8eb-0076-4f8a-a3da-b4991ddc4adc.png">


## Note:

While the current commit does not throw any error, I am still wondering if I can further specify/restrict the contents of the "routes" array. From the understanding, in the current implementation, "routes" will accept any valid array. However in reality, the elements in this array should only be dictionaries/JSON objects that only have two keys (weight and destination). I have tried to achieve this [(as shown in the comments in CommonBindings.cs)](https://github.com/project-radius/bicep/blob/t-tommyniu_radius_typing/src/Bicep.Core/TypeSystem/Radius/V3/CommonBindings.cs#L23), but it resulted in a warning message. Please let me know if my understanding is incorrect, or if there is an alternative way to achieve this.


## Issue reference:
Please reference the issue this PR will close: [#2426](https://github.com/project-radius/radius/issues/2426)



