### PR TITLE
Simplifying Radius import

### DIFF
--- a/src/Bicep.Core/Semantics/Namespaces/RadiusNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/RadiusNamespaceType.cs
@@ -23,7 +23,7 @@ namespace Bicep.Core.Semantics.Namespaces
         {
             return new ObjectType("configuration", TypeSymbolValidationFlags.Default, new TypeProperty[]
             {
-                new TypeProperty("foo", LanguageConstants.String, TypePropertyFlags.Required),
+                // new TypeProperty("foo", LanguageConstants.String, TypePropertyFlags.Required),
                 // new TypeProperty("kubeConfig", LanguageConstants.String, TypePropertyFlags.Required),
                 // new TypeProperty("context", LanguageConstants.String),
             }, null);


### PR DESCRIPTION
* Commented out foo property in radius bicep config

```bicep
import radius as radius {
    foo: 'bar'
}
```
is now
```bicep
import radius as radius
```
