### PR TITLE
Allowing resources to be inputs and outputs

### DIFF
--- a/src/Bicep.Cli/Commands/BuildCommand.cs
+++ b/src/Bicep.Cli/Commands/BuildCommand.cs
@@ -36,10 +36,10 @@ namespace Bicep.Cli.Commands
         {
             var inputPath = PathHelper.ResolvePath(args.InputFile);
 
-            if (invocationContext.Features.ResourceTypedParamsAndOutputsEnabled)
-            {
-                logger.LogWarning(CliResources.ResourceTypesDisclaimerMessage);
-            }
+            // if (invocationContext.Features.ResourceTypedParamsAndOutputsEnabled)
+            // {
+            //     logger.LogWarning(CliResources.ResourceTypesDisclaimerMessage);
+            // }
 
             if (!IsBicepFile(inputPath))
             {

--- a/src/Bicep.Cli/Commands/GenerateParametersFileCommand.cs
+++ b/src/Bicep.Cli/Commands/GenerateParametersFileCommand.cs
@@ -36,10 +36,10 @@ namespace Bicep.Cli.Commands
         {
             var inputPath = PathHelper.ResolvePath(args.InputFile);
 
-            if (invocationContext.Features.ResourceTypedParamsAndOutputsEnabled)
-            {
-                logger.LogWarning(CliResources.ResourceTypesDisclaimerMessage);
-            }
+            // if (invocationContext.Features.ResourceTypedParamsAndOutputsEnabled)
+            // {
+            //     logger.LogWarning(CliResources.ResourceTypesDisclaimerMessage);
+            // }
 
             if (!IsBicepFile(inputPath))
             {

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -20,7 +20,7 @@ namespace Bicep.Core.Features
         private Lazy<bool> importsEnabledLazy = new(() => ReadBooleanEnvVar("BICEP_IMPORTS_ENABLED_EXPERIMENTAL", defaultValue: true), LazyThreadSafetyMode.PublicationOnly);
         public bool ImportsEnabled => importsEnabledLazy.Value;
 
-        private Lazy<bool> resourceTypedParamsAndOutputsEnabledLazy = new(() => ReadBooleanEnvVar("BICEP_RESOURCE_TYPED_PARAMS_AND_OUTPUTS_EXPERIMENTAL", defaultValue: false), LazyThreadSafetyMode.PublicationOnly);
+        private Lazy<bool> resourceTypedParamsAndOutputsEnabledLazy = new(() => ReadBooleanEnvVar("BICEP_RESOURCE_TYPED_PARAMS_AND_OUTPUTS_EXPERIMENTAL", defaultValue: true), LazyThreadSafetyMode.PublicationOnly);
 
         public bool ResourceTypedParamsAndOutputsEnabled => resourceTypedParamsAndOutputsEnabledLazy.Value;
 


### PR DESCRIPTION
Enabling resource inputs and outputs by default.

@rynowak would like your opinion here. Is this something we want to enable by default? I found it when converting a test: https://github.com/project-radius/radius/pull/2808/files#diff-6539f8e767f6aa84260e884f0a946c507e3f8c8f637710a69bd2f84602b59577R13