### PR TITLE
Updating K8sTypeProvider to support metadata.name and metadata.namespace

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -177,6 +177,111 @@ resource myApp 'application' existing = {
         }
 
         [TestMethod]
+        public void Kubernetes_import_existing_warns_with_readonly_fields()
+        {
+            var result = CompilationHelper.Compile(GetCompilationContext(), @"
+import kubernetes as kubernetes {
+  namespace: 'default'
+  kubeConfig: ''
+}
+resource service 'core/Service@v1' existing = {
+  metadata: {
+    name: 'existing-service'
+    namespace: 'default'
+    labels: {
+      format: 'k8s-extension'
+    }
+    annotations: {
+      foo: 'bar'
+    }
+  }
+}
+");
+
+            result.Should().GenerateATemplate();
+            result.Should().HaveDiagnostics(new[] {
+                ("no-unused-existing-resources", DiagnosticLevel.Warning, "Existing resource \"service\" is declared but never used."),
+                ("BCP073", DiagnosticLevel.Warning, "The property \"labels\" is read-only. Expressions cannot be assigned to read-only properties. If this is an inaccuracy in the documentation, please report it to the Bicep Team."),
+                ("BCP073", DiagnosticLevel.Warning, "The property \"annotations\" is read-only. Expressions cannot be assigned to read-only properties. If this is an inaccuracy in the documentation, please report it to the Bicep Team."),
+            });
+        }
+
+        [TestMethod]
+        public void Kubernetes_import_existing_resources()
+        {
+            var result = CompilationHelper.Compile(GetCompilationContext(), @"
+import kubernetes as kubernetes {
+  namespace: 'default'
+  kubeConfig: ''
+}
+resource service 'core/Service@v1' existing = {
+  metadata: {
+    name: 'existing-service'
+    namespace: 'default'
+  }
+}
+resource secret 'core/Secret@v1' existing = {
+  metadata: {
+    name: 'existing-secret'
+    namespace: 'default'
+  }
+}
+resource configmap 'core/ConfigMap@v1' existing = {
+  metadata: {
+    name: 'existing-configmap'
+    namespace: 'default'
+  }
+}
+");
+
+            result.Should().GenerateATemplate();
+            result.Should().HaveDiagnostics(new[] {
+                ("no-unused-existing-resources", DiagnosticLevel.Warning, "Existing resource \"service\" is declared but never used."),
+                ("no-unused-existing-resources", DiagnosticLevel.Warning, "Existing resource \"secret\" is declared but never used."),
+                ("no-unused-existing-resources", DiagnosticLevel.Warning, "Existing resource \"configmap\" is declared but never used."),
+            });
+        }
+
+        [TestMethod]
+        public void Kubernetes_import_existing_connectionstring_test()
+        {
+            var result = CompilationHelper.Compile(GetCompilationContext(), @"
+import kubernetes as kubernetes {
+  namespace: 'default'
+  kubeConfig: ''
+}
+resource redisService 'core/Service@v1' existing = {
+  metadata: {
+    name: 'redis-service'
+    namespace: 'default'
+  }
+}
+resource redisSecret 'core/Secret@v1' existing = {
+  metadata: {
+    name: 'redis-secret'
+    namespace: 'default'
+  }
+}
+resource secret 'core/Secret@v1' = {
+  metadata: {
+    name: 'conn-secret'
+    namespace: 'default'
+    labels: {
+      format: 'k8s-extension'
+    }
+  }
+  stringData: {
+    connectionString: '${redisService.metadata.name}.${redisService.metadata.namespace}.svc.cluster.local,password=${base64ToString(redisSecret.data.redisPassword)}'
+  }
+}
+");
+
+            result.Should().GenerateATemplate();
+            result.Should().NotHaveAnyDiagnostics();
+        }
+
+
+        [TestMethod]
         public void Storage_import_basic_test_with_qualified_type()
         {
             var result = CompilationHelper.Compile(GetCompilationContext(), @"


### PR DESCRIPTION
Cherry-picking https://github.com/Azure/bicep/pull/7709

- Updates K8sTypeProvider to allow for `metadata.name` and `metadata.namespace` to be set.