### PR TITLE
Fix order dependency for build publishing

### DIFF
--- a/.github/workflows/radius-build.yml
+++ b/.github/workflows/radius-build.yml
@@ -132,7 +132,7 @@ jobs:
           echo "comparison: ${{ steps.compare.outputs.comparison-result }}"
       - uses: bacongobbler/azure-blob-storage-upload@v1.2.0
         name: Upload VS Code (stable)
-        if: ${{ success() && steps.compare.outputs.comparison-result == '>' }}
+        if: ${{ success() && (steps.compare.outputs.comparison-result == '>' || steps.compare.outputs.comparison-result == '=')}}
         with:
           container_name: ${{ secrets.ASSETS_STORAGE_CONTAINER }}
           connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}


### PR DESCRIPTION
We have an issue right now where builds of Bicep aren't getting uploaded to the 'stable' URL when they should be.

The root cause is an accidental order dependency in the publishing behavior of two repos. In the Radius repo we have code to update a *marker* file for each new channel (major/minor) we release. The Bicep repo we use this file to decide whether the publish to just the channel or to the channel and the global 'stable' location.

Based on the current code we only publish to 'stable' when the release being build is newer than the marker file. This change fixes the comparison to be >= so we can support either order for cross-repo publishing.

@AaronCrawfis - this is the issue we were talking about