### PR TITLE
Avoid using VSCode settings for feature flags

### DIFF
--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -248,11 +248,12 @@ function configureTelemetry(client: lsp.LanguageClient) {
 }
 
 function getFeatureEnvVars() {
+  // The Radius team really wants this on, and the Bicep team
+  // isn't quite sure....
   const importsEnabledExperimental = vscode.workspace
     .getConfiguration("bicep")
     .get<boolean>("importsEnabledExperimental");
 
   return {
-    BICEP_IMPORTS_ENABLED_EXPERIMENTAL: importsEnabledExperimental,
   };
 }


### PR DESCRIPTION
According to a trusted individual on the Bicep team this is a mistake and shouldn't have been done.

What's happening is that this code is reading from the VSCode settings store and then explicitly using the value to overwrite whatever the defaults are for the language. Given that the Bicep team plans to undo this, I'm working around it in a simple way to make our lives easier next time we merge from upstream.
