### PR TITLE
Allow existing resources for AWS to specify more than name

### DIFF
--- a/src/Bicep.Core.UnitTests/TypeSystem/AWS/AWSResourceTypeProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/AWS/AWSResourceTypeProviderTests.cs
@@ -1,25 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using Bicep.Core.Configuration;
-using Bicep.Core.Diagnostics;
-using Bicep.Core.Semantics;
-using Bicep.Core.TypeSystem;
-using Bicep.Core.TypeSystem.Aws;
-using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Bicep.Core.Extensions;
-using Moq;
-using Bicep.Core.FileSystem;
-using Bicep.Core.Semantics.Namespaces;
-using System.Reflection;
-using Bicep.Core.Resources;
 
 namespace Bicep.Core.UnitTests.TypeSystem.Aws
 {

--- a/src/Bicep.Core/TypeSystem/Aws/AwsResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Aws/AwsResourceTypeProvider.cs
@@ -48,7 +48,7 @@ namespace Bicep.Core.TypeSystem.Aws
         private readonly ResourceTypeCache generatedTypeCache;
 
         public static readonly ImmutableHashSet<string> UniqueIdentifierProperties = new[]
-       {
+        {
             ResourceNamePropertyName,
         }.ToImmutableHashSet();
 


### PR DESCRIPTION
Fixes https://github.com/project-radius/radius/issues/4499