### PR TITLE
Fixing warning with required properties on existing resources

### DIFF
--- a/src/Bicep.Core.UnitTests/TypeSystem/AWS/AWSResourceTypeProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/AWS/AWSResourceTypeProviderTests.cs
@@ -85,5 +85,27 @@ output foo string = s3.name
                 ("BCP035", DiagnosticLevel.Warning, "The specified \"resource\" declaration is missing the following required properties: \"alias\". If this is an inaccuracy in the documentation, please report it to the Bicep Team.")
             });
         }
+
+        [TestMethod]
+        public void AWSResourceTypeProvider_noerror_existing_resource()
+        {
+            var compilation = Services.BuildCompilation(@"
+import aws as aws
+
+resource eksCluster 'AWS.EKS/Cluster@default' existing = {
+  alias: 'test-eks-cluster'
+  properties: {
+    Name: 'test-eks-cluster'
+  }
+}
+
+output foo string = eksCluster.properties.Name
+
+");
+
+            var diag = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
+
+            compilation.Should().NotHaveAnyDiagnostics();
+        }
     }
 }

--- a/src/Bicep.Core/TypeSystem/Aws/AwsResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Aws/AwsResourceTypeProvider.cs
@@ -124,7 +124,7 @@ namespace Bicep.Core.TypeSystem.Aws
             {
                 // TODO apply this to all unique properties
                 properties = properties.SetItem(ResourceNamePropertyName, UpdateFlags(nameProperty, nameProperty.Flags | TypePropertyFlags.LoopVariant));
-                properties = properties.SetItem(ResourceAliasPropertyName, UpdateFlags(aliasProperty, aliasProperty.Flags | TypePropertyFlags.Required | TypePropertyFlags.LoopVariant));
+                properties = properties.SetItem(ResourceAliasPropertyName, UpdateFlags(aliasProperty, aliasProperty.Flags | TypePropertyFlags.Identifier | TypePropertyFlags.Required | TypePropertyFlags.LoopVariant));
 
                 var functions = Array.Empty<Semantics.FunctionOverload>();
                 return new ObjectType(
@@ -170,10 +170,7 @@ namespace Bicep.Core.TypeSystem.Aws
 
         private static TypePropertyFlags HandleIdentifierProperty(TypePropertyFlags typePropertyFlags)
         {
-            if (typePropertyFlags.HasFlag(TypePropertyFlags.Required)) {
-                return typePropertyFlags;
-            }
-            else if (typePropertyFlags.HasFlag(TypePropertyFlags.Identifier)) 
+            if (typePropertyFlags.HasFlag(TypePropertyFlags.Identifier)) 
             {
                 return MakeRequired(typePropertyFlags);
             }


### PR DESCRIPTION
* Fixing issue where bicep compiler would warn if "required" properties were present on existing AWS resources
* Added regression test