### PR TITLE
Initial commit of rad-bicep upload workflow

### DIFF
--- a/.github/workflows/radius-build.yml
+++ b/.github/workflows/radius-build.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Move rad-bicep to release directory
         shell: bash
         run: |
-          mkdir ./release
+          mkdir ${{ env.RELEASE_PATH }}
           cp ./artifacts/bicep/${{ matrix.name }}/rad-bicep${{ matrix.ext }} ./release/$release_file
         env:
           release_file: rad-bicep-${{ matrix.name }}${{ matrix.ext }}
@@ -114,7 +114,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: release
-          path: ./release
+          path: ${{ env.RELEASE_PATH }}
           if-no-files-found: error
   vscode-bicep-build:
     name: Build Bicep vscode extension


### PR DESCRIPTION
This is to upload rad-bicep to github-release.

Release example: 

![image](https://github.com/project-radius/bicep/assets/11863108/0f7b0412-04e3-4590-bd5d-ba5b84b1fd72)
