### PR TITLE
Switch to Actions token for GHCR

### DIFF
--- a/.github/workflows/radius-build.yml
+++ b/.github/workflows/radius-build.yml
@@ -18,8 +18,6 @@ env:
   RELEASE_PATH: ./release
   # ORAS (OCI Registry As Storage) CLI version
   ORAS_VERSION: 1.1.0
-  # GitHub Actor for pushing images to GHCR
-  GHCR_ACTOR: rad-ci-bot
   # Container registry url for GitHub container registry.
   CONTAINER_REGISTRY: 'ghcr.io/radius-project/radius'
   # URL to get source code for building the image
@@ -257,6 +255,9 @@ jobs:
     name: Publish to GHCR
     needs: ["build", "vscode-bicep-build"]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         runtime:
@@ -296,8 +297,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ env.GHCR_ACTOR }}
-          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: oras-project/setup-oras@v1
         with:


### PR DESCRIPTION
This PR updates the Docker login to use the GitHub Actions token instead of the CI-BOT token. This decreases our dependence on a central token