### PR TITLE
Set UPDATE_RELEASE=true for prerelease builds

### DIFF
--- a/.github/scripts/get_release_version.py
+++ b/.github/scripts/get_release_version.py
@@ -88,6 +88,9 @@ with open(os.getenv("GITHUB_ENV"), "a") as githubEnv:
             channel = "REL_CHANNEL={}".format(match.group("version"))
             print("Setting: {}".format(channel))
             githubEnv.write(channel + "\n")
+
+            print("Setting: UPDATE_RELEASE=true")
+            githubEnv.write("UPDATE_RELEASE=true" + "\n")
             sys.exit(0)
 
     print("This is a normal build")


### PR DESCRIPTION
This fixes an issue where prereleases weren't tagged in GHCR: https://github.com/radius-project/bicep/pkgs/container/radius%2Fbicep%2Frad-bicep%2Flinux-x64