### PR TITLE
Add GH action to close stale PRs

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,0 +1,27 @@
+# This workflow warns and then closes PRs that have had no activity for 90 days.
+#
+# For more information, see:
+# https://github.com/actions/stale
+name: Close stale pull requests
+
+on:
+  schedule:
+  - cron: '0 18 * * *' # Run the workflow every day at 6PM UTC (10AM PST).
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This pull request has been automatically marked as stale because it has been inactive for 90 days. Remove stale label or comment or this PR will be closed in 7 days.'
+        stale-pr-label: 'stale'
+        days-before-pr-stale: 90 # 3 months
+        days-before-pr-close: 7
+        days-before-issue-stale: -1
+        days-before-issue-close: -1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,10 @@ If you'd like to contribute to the collection of snippets:
 
 * Submit a PR for review
 
+## Inactive Pull Requests
+
+Pull requests that have been inactive for 90 days will be marked with a stale label. They will automatically be closed after a subsequent 7 days of inactivity. This timeframe may be adjusted in the future based on project needs.
+
 ## Feature Suggestions
 
 * Please first search [Open Bicep Issues](https://github.com/Azure/bicep/issues) before opening an issue to check whether your feature has already been suggested. If it has, feel free to add your own comments to the existing issue.


### PR DESCRIPTION
# Description

To declutter the PR queue and ensure that active contributions receive attention, enabling https://github.com/actions/stale github action to automatically close stale PRs after 90 days of inactivity, with a notification period of 7 days.

This will provide contributors with a reasonable window to address any outstanding feedback or issues before the PR is automatically closed. We can adjust this timeframe in the future based on the feedback and learnings. We can also consider PRs labeled with certain labels to be excluded from this workflow if we see the need for this in the future: https://github.com/actions/stale?tab=readme-ov-file#exempt-pr-labels.

Fixes: https://github.com/radius-project/radius/issues/7151
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
